### PR TITLE
We dont want to die if the code dont existis in Correios db

### DIFF
--- a/lib/WWW/Correios/SRO.pm
+++ b/lib/WWW/Correios/SRO.pm
@@ -261,9 +261,9 @@ sub _sro {
 
     my $html = HTML::TreeBuilder->new_from_content( $response->decoded_content );
     
-    my $table;
+    my $table = $html->find('table');
     
-    return unless $table = $html->find('table');
+    return unless $table;
     
     my @items = $table->find('tr');
 


### PR DESCRIPTION
If we pass a code that not existis, the response will not have a table, and the fist HTML::TreeBuilder::find will returns undef. The second find will die the script.

Ex: http://websro.correios.com.br/sro_bin/txect01$.Inexistente?P_LINGUA=001&P_TIPO=002&P_COD_LIS=RA189611162BR
